### PR TITLE
Update documentation to reference Flask Dashboard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,11 +68,18 @@ We welcome contributions in the following areas:
    - Caching strategies
    - Memory optimization
 
-5. **Features**
+5. **Dashboard and Web Interface**
+   - Dashboard UI/UX improvements
+   - Additional visualization features
+   - API endpoint enhancements
+   - Mobile app development
+   - Multi-user service features (see Dashboard/ISSUE_MULTI_USER_WEB_APP.md)
+
+6. **Features**
    - Data visualization tools
-   - GUI/web interface
    - Additional antenna models
    - Import/export utilities
+   - Integration with external APIs
 
 ### Types of Contributions
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,68 @@ print(f"F2 layer: foF2 = {pnt.f2.fo:.2f} MHz at {pnt.f2.hm:.0f} km")
 
 See [examples/](examples/) for more detailed usage examples.
 
+## 📊 Interactive Dashboard
+
+DVOACAP-Python includes a web-based dashboard for visualizing propagation predictions, DXCC tracking, and real-time band conditions.
+
+### Features
+
+- 🌍 **Interactive Propagation Map** - Visual display of MUF predictions across DX entities
+- 📈 **Band Condition Meters** - Real-time signal quality indicators for 160m-10m
+- 🏆 **DXCC Progress Tracking** - Monitor worked/confirmed entities by band and mode
+- ⚡ **On-Demand Predictions** - One-click refresh with Flask server backend
+- 📡 **Solar Data Integration** - Live solar flux, sunspot numbers, and geomagnetic indices
+- 🎨 **Responsive Design** - Works on desktop and mobile devices
+
+### Quick Start with Dashboard
+
+**Option A: Flask Server (Recommended)**
+
+```bash
+cd Dashboard
+pip install -r requirements.txt
+python3 server.py
+
+# Visit http://localhost:8000
+# Click "⚡ Refresh Predictions" button to generate new predictions
+```
+
+The Flask server provides:
+- API endpoints for prediction generation (`/api/generate`)
+- Real-time progress monitoring (`/api/status`)
+- Background processing (non-blocking)
+- Automatic dashboard reload when complete
+
+**Option B: Static Files**
+
+```bash
+cd Dashboard
+python3 generate_predictions.py
+open dashboard.html
+```
+
+### Configuration
+
+Edit `Dashboard/dvoacap_wrapper.py` to customize:
+- Your callsign and QTH coordinates
+- Station power and antenna characteristics
+- Target bands and DX entities
+- Update frequency
+
+### Dashboard Documentation
+
+See [Dashboard/README.md](Dashboard/README.md) for complete setup instructions, configuration options, and API documentation.
+
+### Future Plans
+
+See [Dashboard/ISSUE_MULTI_USER_WEB_APP.md](Dashboard/ISSUE_MULTI_USER_WEB_APP.md) for the roadmap to expand the dashboard into a multi-user community service with:
+- User authentication and accounts
+- Per-user station configurations
+- Database backend for historical tracking
+- Public API endpoints
+- Mobile app integration
+- Community propagation reporting
+
 ## 📊 Project Status
 
 **Current Phase: 5 of 5 In Progress (85%)**
@@ -154,6 +216,14 @@ dvoacap-python/
 │   │   └── reflectrix.py           # Phase 4
 │   └── original/                   # Reference Pascal source
 │       └── *.pas
+├── Dashboard/                      # Web-based visualization dashboard
+│   ├── server.py                   # Flask API server
+│   ├── dashboard.html              # Interactive dashboard UI
+│   ├── generate_predictions.py     # Prediction generation script
+│   ├── dvoacap_wrapper.py          # DVOACAP integration wrapper
+│   ├── requirements.txt            # Server dependencies
+│   ├── README.md                   # Dashboard documentation
+│   └── ISSUE_MULTI_USER_WEB_APP.md # Multi-user service roadmap
 ├── tests/                          # Test suite
 │   ├── test_path_geometry.py
 │   ├── test_voacap_parser.py
@@ -164,6 +234,8 @@ dvoacap-python/
 │   ├── phase3_ionospheric_example.py
 │   └── phase4_raytracing_example.py
 ├── docs/                           # Documentation
+│   ├── USAGE.md
+│   ├── INTEGRATION.md
 │   └── *.pdf
 ├── DVoaData/                       # CCIR/URSI coefficient data
 └── SampleIO/                       # Sample input/output files

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -340,6 +340,8 @@ async def health_check():
 
 ## Web Dashboard Integration
 
+> **Note:** DVOACAP-Python includes a complete production-ready dashboard in the `Dashboard/` directory with Flask backend, interactive visualizations, and DXCC tracking. See [Dashboard/README.md](../Dashboard/README.md) for setup instructions. The examples below show how to build your own custom dashboards.
+
 ### React Dashboard Example
 
 ```javascript

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -15,6 +15,8 @@ This guide provides comprehensive examples and patterns for using DVOACAP-Python
 
 ## Quick Start
 
+> **Interactive Dashboard:** If you prefer a web-based interface, check out the [Dashboard](../Dashboard/README.md) which provides a complete visualization system with maps, charts, and DXCC tracking.
+
 ### Installation
 
 ```bash


### PR DESCRIPTION
Added comprehensive Dashboard section to README.md covering:
- Interactive features (maps, DXCC tracking, band conditions)
- Quick start for both Flask server and static file options
- Configuration instructions
- Links to Dashboard documentation and multi-user roadmap

Updated CONTRIBUTING.md:
- Added Dashboard and Web Interface as contribution area
- Referenced multi-user service roadmap issue

Updated docs/INTEGRATION.md:
- Added note about production-ready Dashboard in repo
- Clarified that examples show custom dashboard development

Updated docs/USAGE.md:
- Added dashboard reference in Quick Start section
- Pointed users to web interface option

This ensures all documentation references the Flask server work and guides users to the Dashboard for visual interaction.