### PR TITLE
Add optional dashboard dependencies for flexible installation

### DIFF
--- a/Dashboard/README.md
+++ b/Dashboard/README.md
@@ -21,25 +21,39 @@ The dashboard provides **real-time HF propagation forecasts** with:
 
 ## 🚀 Quick Start
 
+### Installation
+
+**Recommended: Install from main package** (ensures DVOACAP library is available)
+```bash
+# From the repository root
+pip install -e ".[dashboard]"
+```
+
+**Alternative: Install just Dashboard dependencies**
+```bash
+cd Dashboard
+pip install -r requirements.txt
+# Note: You'll also need the dvoacap library installed separately
+```
+
+---
+
+### Running the Dashboard
+
 You have two options for running the dashboard:
 
 ### Option A: Web Server with Refresh Button (Recommended)
 
-**1. Install dependencies:**
+**1. Start the server:**
 ```bash
 cd Dashboard
-pip install -r requirements.txt
-```
-
-**2. Start the server:**
-```bash
 python3 server.py
 ```
 
-**3. Open in browser:**
+**2. Open in browser:**
 Visit `http://localhost:8000`
 
-**4. Use the refresh button:**
+**3. Use the refresh button:**
 Click the **⚡ Refresh Predictions** button in the dashboard to generate fresh predictions on demand!
 
 **Benefits:**

--- a/README.md
+++ b/README.md
@@ -17,14 +17,46 @@ DVOACAP-Python is a modern Python port of the [DVOACAP](https://github.com/VE3NE
 
 ### Installation
 
+Choose the installation option that fits your needs:
+
+**Option 1: Core Library Only** (lightweight, for developers)
 ```bash
 # Clone the repository
 git clone https://github.com/skyelaird/dvoacap-python.git
 cd dvoacap-python
 
-# Install in development mode
+# Install just the propagation engine
 pip install -e .
 ```
+
+**Option 2: With Dashboard** (includes Flask server and web UI)
+```bash
+# Clone the repository
+git clone https://github.com/skyelaird/dvoacap-python.git
+cd dvoacap-python
+
+# Install library + dashboard dependencies
+pip install -e ".[dashboard]"
+```
+
+**Option 3: Development Setup** (includes testing tools)
+```bash
+# Clone the repository
+git clone https://github.com/skyelaird/dvoacap-python.git
+cd dvoacap-python
+
+# Install everything
+pip install -e ".[all]"
+```
+
+### What's Included
+
+| Installation | Core Library | Dashboard | Dev Tools |
+|-------------|--------------|-----------|-----------|
+| `pip install -e .` | ✅ | ❌ | ❌ |
+| `pip install -e ".[dashboard]"` | ✅ | ✅ | ❌ |
+| `pip install -e ".[dev]"` | ✅ | ❌ | ✅ |
+| `pip install -e ".[all]"` | ✅ | ✅ | ✅ |
 
 ### Basic Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,12 +46,22 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+dashboard = [
+    "flask>=2.3.0",
+    "flask-cors>=4.0.0",
+    "requests>=2.31.0",
+]
+
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "black>=22.0",
     "flake8>=4.0",
     "mypy>=0.950",
+]
+
+all = [
+    "dvoacap[dashboard,dev]",
 ]
 
 [project.urls]


### PR DESCRIPTION
Implemented optional dependencies pattern to allow users to choose between lightweight core library install vs. full dashboard install.

## Changes

**pyproject.toml:**
- Added [dashboard] optional dependency group with Flask, flask-cors, requests
- Added [all] group to install everything (dashboard + dev tools)
- Users can now choose installation scope based on needs

**README.md:**
- Updated installation section with 3 clear options:
  - Core library only (lightweight)
  - With dashboard (Flask + UI)
  - Development setup (all tools)
- Added comparison table showing what's included in each option

**Dashboard/README.md:**
- Added recommended installation via main package: pip install -e ".[dashboard]"
- Kept alternative method (requirements.txt) for reference
- Fixed step numbering after installation section

## Usage

Core library only:     pip install -e .
With dashboard:        pip install -e ".[dashboard]"
With dev tools:        pip install -e ".[dev]"
Everything:            pip install -e ".[all]"

This allows developers who only need the propagation engine to avoid unnecessary Flask/web dependencies while dashboard users get everything they need in one command.