### PR TITLE
Fix JSON serialization error in predictions generator

### DIFF
--- a/Dashboard/generate_predictions.py
+++ b/Dashboard/generate_predictions.py
@@ -14,6 +14,18 @@ from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from typing import Dict, List, Tuple
 
+
+# Custom JSON encoder to handle numpy types
+class NumpyEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, (np.integer, np.int64, np.int32)):
+            return int(obj)
+        elif isinstance(obj, (np.floating, np.float64, np.float32)):
+            return float(obj)
+        elif isinstance(obj, np.ndarray):
+            return obj.tolist()
+        return super(NumpyEncoder, self).default(obj)
+
 # Add parent directory to path to import dvoacap
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
@@ -285,7 +297,7 @@ def main():
     # Save to JSON
     output_file = Path(__file__).parent / 'propagation_data.json'
     with open(output_file, 'w') as f:
-        json.dump(data, f, indent=2)
+        json.dump(data, f, indent=2, cls=NumpyEncoder)
 
     print()
     print("=" * 80)


### PR DESCRIPTION
Added custom JSON encoder to handle numpy data types (np.int64, np.float64, etc.) that cannot be directly serialized to JSON. This prevents serialization errors when dumping prediction data containing numpy types from calculations.