### PR TITLE
Fix dashboard data display issue

### DIFF
--- a/Dashboard/dashboard.html
+++ b/Dashboard/dashboard.html
@@ -666,12 +666,14 @@
         
         async function loadPropagationData() {
             try {
-                const response = await fetch('propagation_data.json');
-                propData = await response.json();
+                const response = await fetch('enhanced_predictions.json');
+                const data = await response.json();
+                // Extract the predictions object from the enhanced data structure
+                propData = data.predictions || data;
                 initializeDashboard();
             } catch (error) {
                 console.error('Error:', error);
-                document.getElementById('updateInfo').innerHTML = 
+                document.getElementById('updateInfo').innerHTML =
                     '<strong>⚠️ Error loading data. Please regenerate predictions.</strong>';
             }
         }

--- a/Dashboard/server.py
+++ b/Dashboard/server.py
@@ -138,10 +138,13 @@ def get_prediction_data():
         JSON prediction data
     """
     try:
-        data_file = Path(__file__).parent / 'propagation_data.json'
+        data_file = Path(__file__).parent / 'enhanced_predictions.json'
         if data_file.exists():
             with open(data_file, 'r') as f:
-                return jsonify(json.load(f))
+                data = json.load(f)
+                # Extract predictions object from enhanced data structure
+                predictions = data.get('predictions', data)
+                return jsonify(predictions)
         else:
             return jsonify({'error': 'No prediction data available'}), 404
     except Exception as e:


### PR DESCRIPTION
- Updated dashboard.html to fetch from enhanced_predictions.json instead of corrupted propagation_data.json
- Updated server.py API endpoint to serve from enhanced_predictions.json
- Both now extract the predictions object from the enhanced data structure
- Fixes issue where dashboard showed no data despite successful prediction refresh