### PR TITLE
Fix dashboard data loading error

### DIFF
--- a/Dashboard/dashboard.html
+++ b/Dashboard/dashboard.html
@@ -666,7 +666,7 @@
         
         async function loadPropagationData() {
             try {
-                const response = await fetch('propagation_data.json');
+                const response = await fetch('enhanced_predictions.json');
                 const data = await response.json();
                 // Extract the predictions object from the data structure
                 propData = data.predictions || data;

--- a/Dashboard/enhanced_predictions.json
+++ b/Dashboard/enhanced_predictions.json
@@ -16,10 +16,10 @@
               "name": "Africa",
               "quality": "GOOD",
               "reliability": 100.0,
-              "snr_db": 146.1,
+              "snr_db": 145.1,
               "distance_km": 9553,
               "bearing": 94,
-              "muf": 35.81
+              "muf": 14.28
             }
           }
         },
@@ -30,10 +30,10 @@
               "name": "Africa",
               "quality": "GOOD",
               "reliability": 100.0,
-              "snr_db": 149.3,
+              "snr_db": 154.2,
               "distance_km": 9553,
               "bearing": 94,
-              "muf": 35.81
+              "muf": 14.28
             }
           }
         },
@@ -44,10 +44,10 @@
               "name": "Africa",
               "quality": "GOOD",
               "reliability": 100.0,
-              "snr_db": 152.6,
+              "snr_db": 162.2,
               "distance_km": 9553,
               "bearing": 94,
-              "muf": 35.81
+              "muf": 14.28
             }
           }
         },
@@ -58,10 +58,10 @@
               "name": "Africa",
               "quality": "GOOD",
               "reliability": 100.0,
-              "snr_db": 156.9,
+              "snr_db": 166.2,
               "distance_km": 9553,
               "bearing": 94,
-              "muf": 35.81
+              "muf": 14.28
             }
           }
         },
@@ -72,10 +72,10 @@
               "name": "Africa",
               "quality": "GOOD",
               "reliability": 100.0,
-              "snr_db": 161.7,
+              "snr_db": 168.3,
               "distance_km": 9553,
               "bearing": 94,
-              "muf": 35.81
+              "muf": 14.28
             }
           }
         },
@@ -86,10 +86,10 @@
               "name": "Africa",
               "quality": "GOOD",
               "reliability": 100.0,
-              "snr_db": 167.8,
+              "snr_db": 170.4,
               "distance_km": 9553,
               "bearing": 94,
-              "muf": 35.81
+              "muf": 14.28
             }
           }
         },
@@ -100,10 +100,10 @@
               "name": "Africa",
               "quality": "GOOD",
               "reliability": 100.0,
-              "snr_db": 171.5,
+              "snr_db": 172.0,
               "distance_km": 9553,
               "bearing": 94,
-              "muf": 35.81
+              "muf": 14.28
             }
           }
         }


### PR DESCRIPTION
The dashboard was trying to load propagation_data.json directly, but this contains raw VOACAP output format. Updated dashboard.html to load enhanced_predictions.json which contains the properly transformed data structure with current_conditions, timeline_24h, and dxcc objects as expected by the dashboard.

Also ran transform_data.py to generate the enhanced_predictions.json file.