### PR TITLE
Continue Development Work

### DIFF
--- a/test_voacap_reference.py
+++ b/test_voacap_reference.py
@@ -115,13 +115,19 @@ class VoacapReferenceParser:
                            'TGAIN', 'RGAIN', 'SNRxx']
 
             for metric in metric_names:
-                pattern = re.escape(metric) + r'\s+([\d.\s-]+)'
-                match = re.search(pattern, block)
+                # Pattern should match values BEFORE the metric name on same line
+                # Format: "  value1  value2  value3  -  - METRIC_NAME"
+                pattern = r'^\s*([\d.\sEFef-]+?)\s+' + re.escape(metric) + r'\s*$'
+                match = re.search(pattern, block, re.MULTILINE)
                 if match:
                     values_str = match.group(1).split()
                     if metric == 'MODE':
-                        # MODE is text like '1F2', keep as strings
-                        prediction['metrics'][metric] = [v if v != '-' else None for v in values_str]
+                        # MODE is text like '1F2', contains letters
+                        # Need different pattern for MODE
+                        mode_pattern = r'^\s*([\dEFef\s-]+?)\s+MODE\s*$'
+                        mode_match = re.search(mode_pattern, block, re.MULTILINE)
+                        if mode_match:
+                            prediction['metrics'][metric] = [v if v != '-' else None for v in mode_match.group(1).split()]
                     else:
                         # Numeric values
                         prediction['metrics'][metric] = [


### PR DESCRIPTION
Critical Fixes:
1. Fix NaN in _cos_of_incidence() - added guard for negative sqrt values
2. Fix NaN in ground reflection loss - clamp sqrt arguments to non-negative
3. Fix reference parser reading wrong columns - capture values before metric names

Before: All predictions returned NaN for loss/SNR/power
After: Valid predictions with SNR within 10-21 dB of reference (except high freq)

Remaining Issues:
- SNR still 10-21 dB too low (loss too high by same amount)
- High frequencies (>15 MHz) not finding modes

Test Results:
- 1/9 tests passing for hour 1
- No more NaN values
- No more sqrt warnings