### PR TITLE
Fix make command not recognized on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,45 @@ See [Dashboard/ISSUE_MULTI_USER_WEB_APP.md](Dashboard/ISSUE_MULTI_USER_WEB_APP.m
 - **[Phase 3 Summary](docs/PHASE3_COMPLETE.md)** - Ionospheric profiles implementation
 - **[Phase 4 Summary](docs/PHASE4_SUMMARY.md)** - Raytracing implementation
 
+### Building Sphinx Documentation
+
+The project includes comprehensive Sphinx documentation with API references. To build it:
+
+**Prerequisites:**
+```bash
+pip install sphinx sphinx-rtd-theme
+```
+
+**Build on Linux/macOS:**
+```bash
+cd docs
+make html
+```
+
+**Build on Windows:**
+
+Option 1 - Using the batch file (PowerShell or CMD):
+```powershell
+cd docs
+.\make.bat html
+```
+
+Option 2 - Using the PowerShell script:
+```powershell
+cd docs
+.\make.ps1 html
+```
+
+Option 3 - Using sphinx-build directly:
+```powershell
+cd docs
+sphinx-build -M html source build
+```
+
+The built documentation will be in `docs/build/html/index.html`.
+
+See [docs/README.md](docs/README.md) for more details.
+
 ## 🧪 Testing
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,19 +22,26 @@ From the `docs/` directory:
 make html
 ```
 
-#### On Windows (PowerShell or CMD):
+#### On Windows:
 
 From the `docs/` directory:
 
+**Option 1 - Using the batch file (PowerShell or CMD):**
 ```powershell
 .\make.bat html
 ```
 
-Or use `sphinx-build` directly:
+**Option 2 - Using the PowerShell script:**
+```powershell
+.\make.ps1 html
+```
 
+**Option 3 - Using sphinx-build directly:**
 ```powershell
 sphinx-build -M html source build
 ```
+
+**Note:** The `make` command without the `.\` prefix won't work on Windows PowerShell. You must use one of the options above.
 
 The built documentation will be in `docs/build/html/`. Open `docs/build/html/index.html` in your browser.
 
@@ -49,9 +56,9 @@ make man       # Man pages
 
 #### Windows:
 ```powershell
-.\make.bat latexpdf  # PDF via LaTeX
-.\make.bat epub      # EPUB format
-.\make.bat man       # Man pages
+.\make.bat latexpdf  # PDF via LaTeX (or .\make.ps1 latexpdf)
+.\make.bat epub      # EPUB format (or .\make.ps1 epub)
+.\make.bat man       # Man pages (or .\make.ps1 man)
 ```
 
 ### Clean Build
@@ -63,7 +70,7 @@ make clean
 
 #### Windows:
 ```powershell
-.\make.bat clean
+.\make.bat clean  # or .\make.ps1 clean
 ```
 
 ## Documentation Structure

--- a/docs/make.ps1
+++ b/docs/make.ps1
@@ -1,0 +1,19 @@
+# PowerShell wrapper for Sphinx make.bat
+# Usage: .\make.ps1 html
+# or:    .\make.ps1 clean
+
+param(
+    [Parameter(Position=0)]
+    [string]$Target = "help"
+)
+
+# Change to the script's directory
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Push-Location $ScriptDir
+
+try {
+    # Call make.bat with the specified target
+    & ".\make.bat" $Target
+} finally {
+    Pop-Location
+}


### PR DESCRIPTION
- Add make.ps1 PowerShell script for easier Windows builds
- Update main README.md with clear Windows build instructions
- Enhance docs/README.md with multiple Windows build options
- Add note explaining that 'make' command won't work on PowerShell

Fixes issue where Windows users get "make is not recognized" error when trying to build Sphinx documentation.