### PR TITLE
Fix duplicate docstring warnings in antenna_gain.py

### DIFF
--- a/src/dvoacap/antenna_gain.py
+++ b/src/dvoacap/antenna_gain.py
@@ -23,10 +23,6 @@ class AntennaModel:
     Attributes:
         extra_gain_db: Additional gain to add to computed gain (dB)
         tx_power_dbw: Transmit power in dBW
-        frequency: Operating frequency in MHz
-        azimuth: Antenna azimuth angle in radians
-        low_frequency: Lower frequency limit in MHz
-        high_frequency: Upper frequency limit in MHz
     """
 
     def __init__(
@@ -163,7 +159,6 @@ class AntennaFarm:
 
     Attributes:
         antennas: List of available antenna models
-        current_antenna: Currently selected antenna
     """
 
     def __init__(self):


### PR DESCRIPTION
Remove duplicate property documentation from class-level Attributes sections. Properties are already documented via @property decorators with detailed docstrings.

This resolves warnings for:
- AntennaModel.frequency, azimuth, low_frequency, high_frequency
- AntennaFarm.current_antenna

Fixes documentation build warnings where Sphinx was documenting these properties twice: once from the Attributes section and once from the property decorators.