### PR TITLE
Debug GitHub Desktop file visibility issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,6 @@ Dashboard/enhanced_predictions.json
 Dashboard/dxcc_entities.json
 Dashboard/dxcc_summary.json
 Dashboard/pskreporter_data.json
+
+# GitHub Wiki repository (managed separately)
+dvoacap-python.wiki/


### PR DESCRIPTION
The wiki directory is a separate Git repository managed by GitHub for wiki content and should not be tracked in the main repository.