### PR TITLE
Set up automated Sphinx docs deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,54 @@
+name: Build and Deploy Sphinx Documentation
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[docs]"
+
+      - name: Build Sphinx documentation
+        run: |
+          cd docs
+          make html
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/build/html
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,13 +60,18 @@ dev = [
     "mypy>=0.950",
 ]
 
+docs = [
+    "sphinx>=5.0",
+    "sphinx-rtd-theme>=1.0",
+]
+
 all = [
-    "dvoacap[dashboard,dev]",
+    "dvoacap[dashboard,dev,docs]",
 ]
 
 [project.urls]
 Homepage = "https://github.com/skyelaird/dvoacap-python"
-Documentation = "https://github.com/skyelaird/dvoacap-python/tree/main/docs"
+Documentation = "https://skyelaird.github.io/dvoacap-python/"
 Repository = "https://github.com/skyelaird/dvoacap-python"
 "Bug Tracker" = "https://github.com/skyelaird/dvoacap-python/issues"
 "Original DVOACAP" = "https://github.com/VE3NEA/DVOACAP"


### PR DESCRIPTION
This commit adds comprehensive GitHub Pages support for the project's Sphinx documentation:

- Add GitHub Actions workflow (.github/workflows/docs.yml) that automatically builds and deploys Sphinx docs to GitHub Pages on every push to main
- Add 'docs' optional dependencies group in pyproject.toml (Sphinx and sphinx-rtd-theme)
- Update Documentation URL in pyproject.toml to point to the GitHub Pages site: https://skyelaird.github.io/dvoacap-python/

The workflow uses the latest GitHub Actions (v4/v5) and includes proper permissions for Pages deployment. Documentation will be automatically updated whenever changes are pushed to the main branch.