### PR TITLE
Set Up Automatic Wiki Syncing

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,0 +1,58 @@
+name: Sync Wiki
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'wiki/**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync-wiki:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Clone wiki repository
+        run: |
+          git clone https://github.com/${{ github.repository }}.wiki.git wiki-repo
+        continue-on-error: true
+
+      - name: Initialize wiki if it doesn't exist
+        run: |
+          if [ ! -d "wiki-repo" ]; then
+            echo "Wiki repository doesn't exist yet. Please enable the Wiki feature in your repository settings."
+            echo "Once enabled, create at least one page (e.g., Home) via the GitHub UI, then run this workflow again."
+            exit 1
+          fi
+
+      - name: Copy wiki files
+        run: |
+          # Copy all markdown files from wiki/ to wiki-repo/
+          cp wiki/*.md wiki-repo/
+
+      - name: Commit and push changes
+        run: |
+          cd wiki-repo
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Check if there are any changes
+          if git diff --quiet && git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+
+          git add *.md
+          git commit -m "Auto-sync wiki from main repository (commit: ${{ github.sha }})"
+          git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git master
+
+      - name: Summary
+        run: |
+          echo "✅ Wiki synced successfully!"
+          echo "Updated from commit: ${{ github.sha }}"

--- a/scripts/sync-wiki.sh
+++ b/scripts/sync-wiki.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Manual wiki sync script
+# Syncs markdown files from wiki/ directory to GitHub Wiki repository
+
+set -e
+
+REPO_NAME="skyelaird/dvoacap-python"
+WIKI_URL="https://github.com/${REPO_NAME}.wiki.git"
+WIKI_DIR="wiki-repo-temp"
+
+echo "🔄 Starting wiki sync..."
+
+# Check if wiki directory exists
+if [ ! -d "wiki" ]; then
+    echo "❌ Error: wiki/ directory not found"
+    exit 1
+fi
+
+# Clone wiki repository
+echo "📥 Cloning wiki repository..."
+if [ -d "$WIKI_DIR" ]; then
+    rm -rf "$WIKI_DIR"
+fi
+
+git clone "$WIKI_URL" "$WIKI_DIR" || {
+    echo "❌ Error: Could not clone wiki repository"
+    echo "Make sure the Wiki is enabled in repository settings and at least one page exists"
+    exit 1
+}
+
+# Copy markdown files
+echo "📋 Copying markdown files..."
+cp wiki/*.md "$WIKI_DIR/"
+
+# Commit and push
+cd "$WIKI_DIR"
+git config user.name "$(git config --global user.name)"
+git config user.email "$(git config --global user.email)"
+
+if git diff --quiet && git diff --cached --quiet; then
+    echo "✅ No changes to sync"
+    cd ..
+    rm -rf "$WIKI_DIR"
+    exit 0
+fi
+
+echo "💾 Committing changes..."
+git add *.md
+COMMIT_HASH=$(cd .. && git rev-parse --short HEAD)
+git commit -m "Manual wiki sync from repository (commit: $COMMIT_HASH)"
+
+echo "⬆️  Pushing to GitHub Wiki..."
+git push origin master
+
+cd ..
+rm -rf "$WIKI_DIR"
+
+echo "✅ Wiki synced successfully!"

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -116,16 +116,37 @@ wiki/
 
 ## Updating the Wiki
 
+### Automated Sync ✨
+
+**Good news!** Wiki syncing is now automated via GitHub Actions.
+
+When you push changes to the `main` branch that modify files in `wiki/`, the wiki is automatically synced to GitHub Wiki within a few minutes.
+
+**Workflow:** `.github/workflows/wiki-sync.yml`
+
+Just edit the markdown files and push to main - the rest happens automatically!
+
 ### Local Development
 
 Edit markdown files in this directory:
 ```bash
 cd wiki/
 vim Getting-Started.md  # Make your changes
+git add wiki/Getting-Started.md
+git commit -m "Update getting started guide"
+git push origin main  # ← Triggers automatic wiki sync!
 ```
 
-### Syncing to GitHub Wiki
+### Manual Sync (If Needed)
 
+If you need to sync the wiki manually (for testing or troubleshooting):
+
+**Option 1: Use the sync script**
+```bash
+./scripts/sync-wiki.sh
+```
+
+**Option 2: Manual git commands**
 ```bash
 # Clone wiki repo
 git clone https://github.com/skyelaird/dvoacap-python.wiki.git wiki-repo
@@ -140,12 +161,17 @@ git commit -m "Update wiki documentation"
 git push
 ```
 
+**Option 3: Trigger GitHub Action manually**
+1. Go to Actions tab on GitHub
+2. Select "Sync Wiki" workflow
+3. Click "Run workflow"
+
 ### Best Practices
 
 1. **Edit locally first** - Keep wiki/ directory as source of truth
 2. **Test links** - Verify all internal links work
 3. **Preview markdown** - Use a markdown previewer
-4. **Update both places** - Keep wiki/ and GitHub Wiki in sync
+4. **Automatic sync** - Push to main and let GitHub Actions handle the sync
 5. **Commit to main repo** - Wiki markdown is version controlled
 
 ## Wiki Conventions
@@ -270,8 +296,10 @@ If you have questions about the wiki:
 
 ---
 
-**Wiki Status:** ✅ Complete and ready to deploy
+**Wiki Status:** ✅ Complete and ready to deploy (with automatic sync!)
 
-**Last Updated:** 2025-11-14
+**Last Updated:** 2025-11-15
 
 **Total Pages:** 9 (including this README)
+
+**Automation:** Automatic sync via GitHub Actions (`.github/workflows/wiki-sync.yml`)


### PR DESCRIPTION
Implements automatic syncing between repository wiki/ directory and GitHub Wiki.

Changes:
- Add GitHub Actions workflow (.github/workflows/wiki-sync.yml)
  - Automatically syncs wiki/ changes to GitHub Wiki on push to main
  - Can be triggered manually via workflow_dispatch
  - Uses GITHUB_TOKEN for authentication

- Add manual sync script (scripts/sync-wiki.sh)
  - Provides local sync option for testing/troubleshooting
  - Executable bash script with error handling

- Update wiki/README.md documentation
  - Document automatic sync workflow
  - Provide manual sync alternatives
  - Update best practices for new workflow

Benefits:
- No more manual wiki updates needed
- Single source of truth in version control
- Automatic deployment on merge to main
- Manual options still available for edge cases