### PR TITLE
Add GitHub Pages documentation deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,57 @@
+name: Build and Deploy Documentation
+
+on:
+  push:
+    branches: [ main, master ]
+  workflow_dispatch:
+
+# Sets permissions for GitHub Pages deployment
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install sphinx sphinx-rtd-theme
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Build Sphinx documentation
+        run: |
+          cd docs
+          make html
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: docs/_build/html
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,13 +60,18 @@ dev = [
     "mypy>=0.950",
 ]
 
+docs = [
+    "sphinx>=4.0",
+    "sphinx-rtd-theme>=1.0",
+]
+
 all = [
-    "dvoacap[dashboard,dev]",
+    "dvoacap[dashboard,dev,docs]",
 ]
 
 [project.urls]
 Homepage = "https://github.com/skyelaird/dvoacap-python"
-Documentation = "https://github.com/skyelaird/dvoacap-python/tree/main/docs"
+Documentation = "https://skyelaird.github.io/dvoacap-python/"
 Repository = "https://github.com/skyelaird/dvoacap-python"
 "Bug Tracker" = "https://github.com/skyelaird/dvoacap-python/issues"
 "Original DVOACAP" = "https://github.com/VE3NEA/DVOACAP"


### PR DESCRIPTION
- Add GitHub Actions workflow to build and deploy Sphinx docs
- Add 'docs' optional dependency group in pyproject.toml
- Update documentation URL to GitHub Pages location
- Docs will be automatically deployed to https://skyelaird.github.io/dvoacap-python/