### PR TITLE
Fix PowerShell wiki sync script encoding issues

### DIFF
--- a/scripts/sync-wiki.ps1
+++ b/scripts/sync-wiki.ps1
@@ -7,16 +7,16 @@ $REPO_NAME = "skyelaird/dvoacap-python"
 $WIKI_URL = "https://github.com/$REPO_NAME.wiki.git"
 $WIKI_DIR = "wiki-repo-temp"
 
-Write-Host "🔄 Starting wiki sync..." -ForegroundColor Cyan
+Write-Host "[INFO] Starting wiki sync..." -ForegroundColor Cyan
 
 # Check if wiki directory exists
 if (-not (Test-Path "wiki")) {
-    Write-Host "❌ Error: wiki/ directory not found" -ForegroundColor Red
+    Write-Host "[ERROR] wiki/ directory not found" -ForegroundColor Red
     exit 1
 }
 
 # Clone wiki repository
-Write-Host "📥 Cloning wiki repository..." -ForegroundColor Cyan
+Write-Host "[INFO] Cloning wiki repository..." -ForegroundColor Cyan
 if (Test-Path $WIKI_DIR) {
     Remove-Item -Recurse -Force $WIKI_DIR
 }
@@ -24,20 +24,20 @@ if (Test-Path $WIKI_DIR) {
 try {
     $cloneOutput = git clone $WIKI_URL $WIKI_DIR 2>&1
     if ($LASTEXITCODE -ne 0) {
-        Write-Host "❌ Error: Could not clone wiki repository" -ForegroundColor Red
+        Write-Host "[ERROR] Could not clone wiki repository" -ForegroundColor Red
         Write-Host "Git output: $cloneOutput" -ForegroundColor Yellow
         Write-Host "Make sure the Wiki is enabled in repository settings and at least one page exists" -ForegroundColor Yellow
         exit 1
     }
 } catch {
-    Write-Host "❌ Error: Could not clone wiki repository" -ForegroundColor Red
+    Write-Host "[ERROR] Could not clone wiki repository" -ForegroundColor Red
     Write-Host "Exception: $_" -ForegroundColor Yellow
     Write-Host "Make sure the Wiki is enabled in repository settings and at least one page exists" -ForegroundColor Yellow
     exit 1
 }
 
 # Copy markdown files
-Write-Host "📋 Copying markdown files..." -ForegroundColor Cyan
+Write-Host "[INFO] Copying markdown files..." -ForegroundColor Cyan
 Copy-Item "wiki\*.md" "$WIKI_DIR\" -Force
 
 # Commit and push
@@ -51,37 +51,37 @@ git config user.email $userEmail
 # Check for changes
 $addOutput = git add *.md 2>&1
 if ($LASTEXITCODE -ne 0) {
-    Write-Host "❌ Error: Failed to add markdown files" -ForegroundColor Red
+    Write-Host "[ERROR] Failed to add markdown files" -ForegroundColor Red
     Write-Host "Git output: $addOutput" -ForegroundColor Yellow
     Pop-Location
     exit 1
 }
 $status = git status --porcelain
 if ([string]::IsNullOrWhiteSpace($status)) {
-    Write-Host "✅ No changes to sync" -ForegroundColor Green
+    Write-Host "[SUCCESS] No changes to sync" -ForegroundColor Green
     Pop-Location
     Remove-Item -Recurse -Force $WIKI_DIR
     exit 0
 }
 
-Write-Host "💾 Committing changes..." -ForegroundColor Cyan
+Write-Host "[INFO] Committing changes..." -ForegroundColor Cyan
 Push-Location ..
 $COMMIT_HASH = git rev-parse --short HEAD
 Pop-Location
 $commitOutput = git commit -m "Manual wiki sync from repository (commit: $COMMIT_HASH)" 2>&1
 
 if ($LASTEXITCODE -ne 0) {
-    Write-Host "❌ Error: Failed to commit changes" -ForegroundColor Red
+    Write-Host "[ERROR] Failed to commit changes" -ForegroundColor Red
     Write-Host "Git output: $commitOutput" -ForegroundColor Yellow
     Pop-Location
     exit 1
 }
 
-Write-Host "⬆️  Pushing to GitHub Wiki..." -ForegroundColor Cyan
+Write-Host "[INFO] Pushing to GitHub Wiki..." -ForegroundColor Cyan
 $pushOutput = git push origin master 2>&1
 
 if ($LASTEXITCODE -ne 0) {
-    Write-Host "❌ Error: Failed to push to wiki repository" -ForegroundColor Red
+    Write-Host "[ERROR] Failed to push to wiki repository" -ForegroundColor Red
     Write-Host "Git output: $pushOutput" -ForegroundColor Yellow
     Pop-Location
     exit 1
@@ -90,4 +90,4 @@ if ($LASTEXITCODE -ne 0) {
 Pop-Location
 Remove-Item -Recurse -Force $WIKI_DIR
 
-Write-Host "✅ Wiki synced successfully!" -ForegroundColor Green
+Write-Host "[SUCCESS] Wiki synced successfully!" -ForegroundColor Green


### PR DESCRIPTION
- Replace emoji characters with ASCII-safe text labels ([INFO], [ERROR], [SUCCESS])
- Emojis were causing PowerShell to misinterpret and print script instead of executing it
- This resolves the issue where the script would fail at the git clone step