### PR TITLE
Fetch real Kp and A-index values

### DIFF
--- a/Dashboard/README.md
+++ b/Dashboard/README.md
@@ -73,7 +73,7 @@ python3 generate_predictions.py
 ```
 
 This will:
-- Fetch current solar-terrestrial conditions from NOAA
+- Fetch current solar-terrestrial conditions from NOAA SWPC (SFI, SSN, Kp, A-index)
 - Run DVOACAP predictions for all bands and regions
 - Generate `propagation_data.json` with 24-hour forecasts
 - Takes ~30-60 seconds depending on your system
@@ -120,11 +120,11 @@ For best results, regenerate predictions:
 
 ### Solar Conditions
 
-The dashboard displays current:
-- **SFI** (Solar Flux Index) - Higher = better HF conditions
-- **SSN** (Sunspot Number) - Indicates solar cycle phase
-- **Kp** (Geomagnetic activity) - Lower = more stable propagation
-- **A-index** (Absorption) - Lower = less D-layer absorption
+The dashboard displays current conditions fetched live from NOAA Space Weather Prediction Center:
+- **SFI** (Solar Flux Index) - Higher = better HF conditions (fetched from F10.7 cm flux data)
+- **SSN** (Sunspot Number) - Indicates solar cycle phase (fetched from observed solar cycle indices)
+- **Kp** (Geomagnetic activity) - Lower = more stable propagation (fetched from planetary K-index)
+- **A-index** (Absorption) - Lower = less D-layer absorption (fetched from predicted A-index data)
 
 ---
 
@@ -419,7 +419,13 @@ python3 generate_predictions.py
 
 **Error**: "Could not fetch live solar data"
 
-**Solution**: The script will use default values. This is normal if NOAA API is temporarily unavailable. Predictions will still work.
+**Solution**: The script will use default values (SFI=150, SSN=100, Kp=2.0, A=10). This is normal if NOAA SWPC API is temporarily unavailable. Predictions will still work with these mid-cycle defaults.
+
+**Data Sources**:
+- SFI: https://services.swpc.noaa.gov/json/f107_cm_flux.json
+- SSN: https://services.swpc.noaa.gov/json/solar-cycle/observed-solar-cycle-indices.json
+- Kp: https://services.swpc.noaa.gov/json/planetary_k_index_1m.json
+- A-index: https://services.swpc.noaa.gov/json/predicted_fredericksburg_a_index.json
 
 ### Slow Prediction Generation
 

--- a/wiki/Dashboard-Guide.md
+++ b/wiki/Dashboard-Guide.md
@@ -113,7 +113,7 @@ python3 generate_predictions.py
 ```
 
 This will:
-- Fetch current solar data from NOAA
+- Fetch current solar data from NOAA SWPC (SFI, SSN, Kp, A-index)
 - Run DVOACAP predictions for all configured bands and regions
 - Generate `propagation_data.json` (takes 30-60 seconds)
 
@@ -260,25 +260,33 @@ The dashboard uses color-coded indicators to show band conditions:
 
 ### Solar Conditions Display
 
+All solar-terrestrial indices are fetched live from NOAA Space Weather Prediction Center:
+
 **SFI (Solar Flux Index):**
 - Measured at 10.7 cm wavelength
 - Higher values = better HF conditions
 - Typical range: 70-250
+- **Source**: https://services.swpc.noaa.gov/json/f107_cm_flux.json
 
 **SSN (Sunspot Number):**
 - Indicates solar cycle phase
 - Higher during solar maximum
 - Typical range: 0-300
+- **Source**: https://services.swpc.noaa.gov/json/solar-cycle/observed-solar-cycle-indices.json
 
 **Kp Index:**
 - Geomagnetic activity (0-9 scale)
 - Lower = more stable propagation
 - Kp > 5 indicates disturbed conditions
+- **Source**: https://services.swpc.noaa.gov/json/planetary_k_index_1m.json
 
 **A-Index:**
 - D-layer absorption indicator
 - Lower = less absorption
 - High A-index degrades low-band propagation
+- **Source**: https://services.swpc.noaa.gov/json/predicted_fredericksburg_a_index.json
+
+**Note**: If NOAA APIs are unavailable, the system falls back to default mid-cycle values (SFI=150, SSN=100, Kp=2.0, A=10).
 
 ---
 
@@ -538,11 +546,15 @@ python3 generate_predictions.py
 
 **Symptom:** "Could not fetch live solar data" message.
 
-**Cause:** NOAA API temporarily unavailable.
+**Cause:** NOAA SWPC API temporarily unavailable or network issues.
 
-**Impact:** Predictions will use default values (SSN=100). This is normal and predictions will still work.
+**Impact:** Predictions will use default mid-cycle values (SFI=150, SSN=100, Kp=2.0, A=10). This is normal and predictions will still work.
 
-**Solution:** The script automatically retries and uses reasonable defaults.
+**Solution:** The script automatically handles failures gracefully:
+- Each index (SFI, SSN, Kp, A) is fetched independently
+- If some indices fail, others may still be fetched successfully
+- Check output messages to see which indices were fetched live vs. using defaults
+- The 'source' field in solar_conditions indicates if data is 'NOAA SWPC (live)' or 'defaults'
 
 ---
 

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -220,18 +220,24 @@ See [Quick Examples](Quick-Examples) for more examples.
 ### What solar and geomagnetic parameters do I need?
 
 **Required parameters:**
-- **SSN (Sunspot Number):** 0-300 (typical: 0-200)
 - **Month:** 1-12
 - **UTC time:** 0-24 hours
 
-**Optional (auto-computed if not provided):**
-- **Solar Flux Index (SFI):** Auto-derived from SSN
-- **Kp index:** Defaults to 2 (quiet conditions)
-- **A-index:** Defaults to 8 (low absorption)
+**Automatically fetched (when using Dashboard):**
+- **SFI (Solar Flux Index):** Fetched live from NOAA SWPC (F10.7 cm flux)
+- **SSN (Sunspot Number):** Fetched live from NOAA SWPC (observed solar cycle indices)
+- **Kp index:** Fetched live from NOAA SWPC (planetary K-index)
+- **A-index:** Fetched live from NOAA SWPC (predicted A-index)
 
-**Where to get current values:**
-- NOAA Space Weather: https://www.swpc.noaa.gov/
-- Dashboard auto-fetches from NOAA API
+**For manual API usage:**
+- **SSN (Sunspot Number):** 0-300 (typical: 0-200)
+- **Kp index:** 0-9 (typical: 0-5, defaults to 2 for quiet conditions)
+- **A-index:** 0-400 (typical: 0-50, defaults to 10 for low absorption)
+
+**Data Sources:**
+- NOAA SWPC: https://www.swpc.noaa.gov/
+- Dashboard auto-fetches from: https://services.swpc.noaa.gov/json/
+- Manual fetch: See `Dashboard/generate_predictions.py` for implementation
 
 ---
 


### PR DESCRIPTION
Implement real-time fetching of solar-terrestrial indices from NOAA Space Weather Prediction Center APIs instead of using hardcoded defaults.

Changes:
- Update fetch_solar_conditions() to fetch live data from NOAA SWPC JSON APIs
  - SFI: https://services.swpc.noaa.gov/json/f107_cm_flux.json
  - SSN: https://services.swpc.noaa.gov/json/solar-cycle/observed-solar-cycle-indices.json
  - Kp: https://services.swpc.noaa.gov/json/planetary_k_index_1m.json
  - A-index: https://services.swpc.noaa.gov/json/predicted_fredericksburg_a_index.json
- Each index is fetched independently with graceful fallback to defaults
- Add 'source' field to track whether data is live or default
- Update Dashboard/README.md with live fetching information
- Update wiki/Dashboard-Guide.md with data sources and troubleshooting
- Update wiki/FAQ.md to reflect auto-fetching behavior

Benefits:
- More accurate predictions using current space weather conditions
- No manual parameter updates needed
- Graceful degradation if APIs are unavailable
- Better visibility into data sources