### PR TITLE
Fix duplicate 'now' declarations breaking dashboard JS

### DIFF
--- a/src/dvoacap/dashboard/dashboard.html
+++ b/src/dvoacap/dashboard/dashboard.html
@@ -1669,22 +1669,20 @@
             renderBestBands();
 
             // Initialize gray line time slider to current hour
-            const now = new Date();
-            const currentHour = now.getUTCHours();
-            document.getElementById('grayLineTimeSlider').value = currentHour;
+            const currentHourInt = new Date().getUTCHours();
+            document.getElementById('grayLineTimeSlider').value = currentHourInt;
             document.getElementById('grayLineTimeValue').textContent =
-                `${String(currentHour).padStart(2, '0')}:00`;
+                `${String(currentHourInt).padStart(2, '0')}:00`;
 
             // Update gray line every 5 minutes (only when using current time)
             setInterval(() => {
                 if (grayLineHour === null) {
                     updateGrayLine();
                     // Update slider if showing current time
-                    const now = new Date();
-                    const currentHour = now.getUTCHours();
-                    document.getElementById('grayLineTimeSlider').value = currentHour;
+                    const tickHour = new Date().getUTCHours();
+                    document.getElementById('grayLineTimeSlider').value = tickHour;
                     document.getElementById('grayLineTimeValue').textContent =
-                        `${String(currentHour).padStart(2, '0')}:00`;
+                        `${String(tickHour).padStart(2, '0')}:00`;
                 }
             }, 300000);
         }


### PR DESCRIPTION
## Summary

`initializeDashboard()` declared `const now` and `const currentHour` twice in the same scope (lines 1658 and 1672). Modern browsers reject this with a parse-time `SyntaxError: Identifier 'now' has already been declared`, which silently kills the entire `<script>` block — no event handlers get attached, no buttons work, and no `/api/*` calls are ever made even though `dashboard.html` renders.

The two uses had different semantics (fractional hour for `grayLineSlider`, integer hour for `grayLineTimeSlider`), so I renamed the second pair to `currentHourInt` and `tickHour` rather than dedupe.

## Repro

1. `pip install -e ".[dashboard]"` and run `dvoacap-dashboard`.
2. Load `http://localhost:8000` in any modern browser.
3. Open DevTools Console — observe the `SyntaxError` plus a cascade of `triggerRefresh is not defined`, `showSettings is not defined`, `showTab is not defined` ReferenceErrors.
4. Click any button: nothing happens, server log shows no `/api/...` request.

## Test plan

- [x] Open dashboard in browser, hard-reload, verify Console is clean.
- [x] Click "Refresh Predictions" → server log shows `POST /api/generate`.
- [x] Click tabs (Band Details, Propagation Charts, etc.) → tab content switches.

https://claude.ai/code/session_01PLeFRjjJUKnUAjA5imhsZz

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLeFRjjJUKnUAjA5imhsZz)_