### PR TITLE
Fix duplicate 'now' declaration in served.html so dashboard buttons work

### DIFF
--- a/served.html
+++ b/served.html
@@ -1669,22 +1669,20 @@
             renderBestBands();
 
             // Initialize gray line time slider to current hour
-            const now = new Date();
-            const currentHour = now.getUTCHours();
-            document.getElementById('grayLineTimeSlider').value = currentHour;
+            const currentHourInt = new Date().getUTCHours();
+            document.getElementById('grayLineTimeSlider').value = currentHourInt;
             document.getElementById('grayLineTimeValue').textContent =
-                `${String(currentHour).padStart(2, '0')}:00`;
+                `${String(currentHourInt).padStart(2, '0')}:00`;
 
             // Update gray line every 5 minutes (only when using current time)
             setInterval(() => {
                 if (grayLineHour === null) {
                     updateGrayLine();
                     // Update slider if showing current time
-                    const now = new Date();
-                    const currentHour = now.getUTCHours();
-                    document.getElementById('grayLineTimeSlider').value = currentHour;
+                    const tickHour = new Date().getUTCHours();
+                    document.getElementById('grayLineTimeSlider').value = tickHour;
                     document.getElementById('grayLineTimeValue').textContent =
-                        `${String(currentHour).padStart(2, '0')}:00`;
+                        `${String(tickHour).padStart(2, '0')}:00`;
                 }
             }, 300000);
         }


### PR DESCRIPTION
## Summary

The user reported the dashboard "not responsive" — the Refresh and Settings buttons did nothing — and shared a browser console with three errors:

```
Uncaught SyntaxError: Identifier 'now' has already been declared    (index):1672
Uncaught ReferenceError: triggerRefresh is not defined              (index):693:76
Uncaught ReferenceError: showSettings is not defined                (index):698:194
```

All three are caused by a single bug. Inside `initializeDashboard()` in `served.html`, `const now = new Date()` was declared on line 1658 and then re-declared on line 1672 in the same block scope. The same pattern repeated inside the function's `setInterval` callback. The resulting `SyntaxError` aborts parsing of the entire `<script>` block, so the top-level `triggerRefresh` (defined at line 2864) and `showSettings` (line 3447) never become callable, and the inline `onclick` handlers on lines 693 and 698 fail with `ReferenceError`.

This is the same bug that was fixed in `src/dvoacap/dashboard/dashboard.html` in commit `f1c1faf` (PR #134), but the captured `served.html` snapshot at the repo root never received the fix. This PR mirrors that fix — renaming the duplicate locals to `currentHourInt` and `tickHour` — so `served.html` matches `dashboard.html` byte-for-byte.

## Test plan

- [x] `diff src/dvoacap/dashboard/dashboard.html served.html` is empty
- [x] Extracted inline JS from `served.html` parses with `node --check` (previously failed at line 1672)
- [x] `triggerRefresh` and `showSettings` are top-level function declarations, so they reach `window` once the script parses
- [ ] Load the dashboard in a browser and confirm the Refresh / Settings buttons fire (also: if your installed package predates `f1c1faf`, run `pip install -e ".[dashboard]" --force-reinstall` and hard-refresh)

https://claude.ai/code/session_01BLfWHK9hf8k4aBBaQjfQa8

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLfWHK9hf8k4aBBaQjfQa8)_