### PR TITLE
Fix nonsense signal/SNR for HF paths longer than 7000 km

### DIFF
--- a/src/dvoacap/prediction_engine.py
+++ b/src/dvoacap/prediction_engine.py
@@ -227,8 +227,6 @@ class PredictionEngine:
         self.utc_time = utc_time
         self.frequencies = frequencies.copy()
 
-        # Initialize transmit power
-        self.tx_antennas.current_antenna.tx_power_dbw = self._to_db(self.params.tx_power)
         self.muf_calculator.min_angle = self.params.min_angle
 
         # Allocate results array
@@ -296,6 +294,12 @@ class PredictionEngine:
         for f, freq in enumerate(self.frequencies):
             self.tx_antennas.select_antenna(freq)
             self.rx_antennas.select_antenna(freq)
+            # Stamp the configured TX power onto whichever antenna was just
+            # selected; setting it once before the loop only writes to the
+            # isotropic default and gets shadowed when select_antenna swaps
+            # in a user-added antenna whose own tx_power_dbw came from its
+            # constructor (typically a placeholder).
+            self.tx_antennas.current_antenna.tx_power_dbw = self._to_db(self.params.tx_power)
 
             # Compute noise distribution
             fof2 = self._profiles[-1].f2.fo
@@ -311,11 +315,13 @@ class PredictionEngine:
             # Evaluate short model
             prediction = self._evaluate_short_model(reflectrix, f)
 
-            # Combine with long model if needed
-            if self.path.dist >= self.RAD_7000_KM:
-                long_pred = self._evaluate_long_model(freq)
-                prediction = self._combine_short_and_long(prediction, long_pred)
-
+            # Long-path model is not implemented (_evaluate_long_model is a
+            # stub that returns an empty Prediction). Calling
+            # _combine_short_and_long with that stub would let its zero-valued
+            # power_dbw pollute the smooth-interpolation branch and back-
+            # derive a near-zero total_loss for any path between 7000 and
+            # 10000 km, or hand back an all-zero prediction beyond 10000 km.
+            # Until the long-path model is real, always use the short result.
             self.predictions[f] = prediction
 
     def _compute_control_points(self) -> None:

--- a/tests/test_prediction_engine.py
+++ b/tests/test_prediction_engine.py
@@ -1,0 +1,91 @@
+"""Regression tests for PredictionEngine.
+
+Guards against the long-path stub bug where _evaluate_long_model returned an
+empty Prediction() and _combine_short_and_long mixed it into the result for
+paths >= 7000 km, producing absurdly high signal_dbw / SNR for mid-range
+distances and an all-zero prediction beyond 10000 km.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from dvoacap.path_geometry import GeoPoint
+from dvoacap.prediction_engine import PredictionEngine
+
+
+def _run_prediction(distance_km_target: float, freq_mhz: float = 14.1):
+    """Run a prediction along the equator at roughly the requested distance."""
+    eng = PredictionEngine()
+    eng.params.ssn = 60
+    eng.params.month = 5
+    eng.params.tx_power = 100.0
+    eng.params.tx_location = GeoPoint.from_degrees(0.0, 0.0)
+
+    # Approximate longitude offset for a great-circle distance along the equator.
+    # Earth radius is 6370 km in the engine.
+    lon_deg = float(distance_km_target / 6370.0 * 180.0 / np.pi)
+    rx = GeoPoint.from_degrees(0.0, lon_deg)
+
+    eng.predict(rx_location=rx, utc_time=18 / 24.0, frequencies=[freq_mhz])
+    return eng.predictions[0], eng.path.dist * 6370.0
+
+
+@pytest.mark.parametrize("distance_km", [4500, 8500, 11000])
+def test_long_distance_signal_is_physically_plausible(distance_km):
+    """Signal level must reflect a real path-loss budget, not a stub bypass.
+
+    For HF on 20 m at these distances, received power against a 100 W TX with
+    isotropic antennas should sit well below 0 dBW; SNR likewise capped well
+    below the dB regime that signaled the stub-mixing bug (>+100 dB).
+    """
+    pred, actual_distance = _run_prediction(distance_km)
+
+    assert pred.signal.power_dbw < -50.0, (
+        f"Received power {pred.signal.power_dbw:.1f} dBW at "
+        f"{actual_distance:.0f} km is implausibly high for HF; long-path stub "
+        f"likely leaking back in."
+    )
+    assert pred.signal.snr_db < 100.0, (
+        f"SNR {pred.signal.snr_db:.1f} dB at {actual_distance:.0f} km is "
+        f"physically impossible; long-path stub bug regressed."
+    )
+    assert pred.signal.total_loss_db > 80.0, (
+        f"total_loss_db {pred.signal.total_loss_db:.1f} dB at "
+        f"{actual_distance:.0f} km is far too low for an HF skywave path."
+    )
+
+
+def test_tx_power_propagates_to_user_added_antenna():
+    """tx_power_dbw must reach whichever antenna select_antenna picks, not
+    just the isotropic default that current_antenna points at before the
+    per-frequency loop."""
+    from dvoacap.antenna_gain import VerticalMonopole
+
+    eng = PredictionEngine()
+    eng.params.ssn = 60
+    eng.params.month = 5
+    eng.params.tx_power = 100.0  # 100 W -> 20 dBW
+    eng.params.tx_location = GeoPoint.from_degrees(0.0, 0.0)
+
+    # Construct an antenna with a deliberately wrong placeholder power so the
+    # bug, if regressed, is unmistakable.
+    ant = VerticalMonopole(
+        low_frequency=14.0, high_frequency=14.5, tx_power_dbw=-30.0
+    )
+    eng.tx_antennas.add_antenna(ant)
+    eng.rx_antennas.add_antenna(ant)
+
+    eng.predict(
+        rx_location=GeoPoint.from_degrees(0.0, 40.0),
+        utc_time=18 / 24.0,
+        frequencies=[14.1],
+    )
+
+    assert eng.tx_antennas.current_antenna.tx_power_dbw == pytest.approx(
+        20.0, abs=1e-6
+    ), (
+        "params.tx_power=100W must be stamped onto the selected antenna; "
+        f"got {eng.tx_antennas.current_antenna.tx_power_dbw} dBW."
+    )


### PR DESCRIPTION
## Summary

Fix two bugs in `PredictionEngine` that together produced the constant `-0.7 dBW` signal levels and absurd ±150–270 dB SNRs the user observed in the dashboard for every region beyond 7000 km.

### Bug 1: long-path stub leaks into result

`_evaluate_long_model()` is a documented stub (`# Simplified implementation - would need two Reflectrix objects. For now, return a basic prediction.`) that returns an empty `Prediction()`. For any path ≥ 7000 km, `predict()` was calling `_combine_short_and_long(short_pred, long_pred)` with that stub.

A default `Prediction()` has `signal.power_dbw = 0.0`. `_combine_short_and_long` mixed the zero into the result:

- **Distance ≥ 10000 km:** returned `long_pred` directly → all-zero signal, `total_loss_db` back-derived to `tx_power_dbw - 0 ≈ 20 dB`.
- **7000 km ≤ distance < 10000 km:** smooth-interpolated toward 0 dBW. With a typical `short_pwr10` of −120 dBW, the math collapses to `power_dbw ≈ 10·log10(r) ≈ −0.7 dBW` — exactly the constant signal level the dashboard rendered.

Short paths weren't fixed by this either: `current_conditions` showed regions like CA/EU/UK/SA at 10 m with SNRs of −223 / −267 / −234 dB, where short-model predictions on a frequency far above MUF produced large `total_loss_db` values that propagated through correctly *into the short pred* but then got clobbered by the same combine-step writeback for any portion crossing 7000 km.

Until a real long-path model exists, this PR skips the combine step entirely and always uses the short prediction. The short model is already valid out past 10000 km; the F2 multi-hop tracking just gets less accurate, which is strictly preferable to the engine inventing signal.

### Bug 2: TX power doesn't reach user-added antennas

`predict()` set `tx_power_dbw` on `current_antenna` once, *before* the per-frequency loop where `select_antenna()` swaps in the right antenna. At that early point `current_antenna` is still the isotropic default, so the user's vertical/yagi/dipole kept whatever placeholder its constructor set (the dashboard uses `tx_power_dbw=10.0`, comment says "Will be set from engine.params.tx_power" — but nothing ever did). Net effect: a configured 100 W (20 dBW) TX was being treated as 10 W on every dashboard prediction.

Move the assignment inside the per-frequency loop, after `select_antenna()`.

### Verified output

For Halifax → Africa equivalent (~9500 km) at 14.1 MHz, 100 W, vertical antennas:

| metric | before | after |
|---|---|---|
| `total_loss_db` | 10.07 | 171.13 |
| `power_dbw` | −0.07 | −150.37 |
| `snr_db` | +154.73 | +4.44 |
| `reliability` | 1.000 | 0.000 |

(SNR is now a normal-looking +4 dB, marginal-copy regime, as you'd expect for a 9500 km daytime path on 20 m.)

## Test plan

- [x] Existing test suite passes — 318 → 322 tests, all green
- [x] `test_voacap_validation.py` still produces sensible numbers (loss 157.3 dB, SNR 26.2 dB to London at 4689 km)
- [x] `validate_dvoacap.py` reports `VALIDATION SUCCESSFUL`
- [x] New regression tests in `tests/test_prediction_engine.py`:
  - signal levels at 4500 / 8500 / 11000 km satisfy `power_dbw < −50 dBW`, `snr_db < +100 dB`, `total_loss_db > 80 dB` (every assertion was clearly violated by the stub-mixing bug)
  - `params.tx_power` propagates through to a user-added antenna whose constructor used a placeholder value
- [ ] Refresh predictions on a real dashboard install, fetch `/api/data`, confirm `signal_dbw` now varies hour-to-hour and regions, and reliability is no longer pinned at 100% / 0%

## Out of scope for this PR

- The 10 m short-path SNR oddities (e.g. −267 dB to EU) likely come from a separate sign issue in the muf-penalty path. Worth a follow-up once we have data showing whether they persist after this fix.
- Implementing a real `_evaluate_long_model`. The stub is preserved as-is; only its consumption is bypassed.

https://claude.ai/code/session_01BLfWHK9hf8k4aBBaQjfQa8

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLfWHK9hf8k4aBBaQjfQa8)_