### PR TITLE
Release v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-05-01
+
+### Fixed
+
+- **Long-path signal/SNR calculation** - For HF paths longer than 7000 km, the engine was mixing in an unimplemented `_evaluate_long_model` stub that returned an empty `Prediction()`. The smooth-interpolation branch in `_combine_short_and_long` then pulled `power_dbw` toward 0 dBW and back-derived a nonsensically small `total_loss_db`, producing constant `-0.7 dBW` signal levels and SNRs of +150 dB or worse for any region beyond 7000 km, with reliability pinned at 100%. Paths beyond 10000 km returned all-zero predictions outright. Until a real long-path model exists, the short-path result is used at all distances. (#137)
+- **TX power propagation to user-added antennas** - `params.tx_power` was stamped onto `current_antenna` once before the per-frequency loop, where `current_antenna` still pointed at the isotropic default. `select_antenna()` then swapped in the user antenna whose `tx_power_dbw` came from its constructor, leaving a 100 W radio configuration treated as 10 W (a 10 dB undercount). The assignment now happens inside the loop after antenna selection. (#137)
+- **Dashboard buttons unresponsive** - A duplicate `const now` declaration inside `initializeDashboard()` (and again inside its `setInterval` callback) caused a `SyntaxError` that prevented the entire `<script>` block from parsing, leaving `triggerRefresh` and `showSettings` undefined when their `onclick` handlers fired. Renamed the duplicate locals to `currentHourInt` / `tickHour`. (#134, #135)
+- **Gray-line terminator rendering** - `drawGrayLine()` swept a 2° lat/lon grid for points where `|solar altitude| < 6°`, then bucketed them into 5°-wide latitude bands and emitted one rectangle per (band, longitude segment), rendering the twilight zone as a visible staircase of 10°-tall blocks. Replaced with a closed-form analytic solve at every longitude, drawn as a single smooth polygon. (#136)
+
+### Added
+
+- **Regression tests for `PredictionEngine`** - Asserts long-distance predictions produce physically plausible signal levels and that `params.tx_power` reaches user-added antennas. (#137)
+
+### Changed
+
+- **Dashboard packaged as installable subpackage** - Moved from `Dashboard/` to `src/dvoacap/dashboard/`, added `dvoacap-dashboard` console-script entry point, and shipped HTML/JS/CSS with the package so `pip install dvoacap[dashboard]` followed by `dvoacap-dashboard` is sufficient. Backward-compatible `python Dashboard/server.py` shim retained. (#133)
+
 ## [1.0.1] - 2025-11-18
 
 ### 🚀 Performance Optimizations

--- a/INSTALL_GUIDE.md
+++ b/INSTALL_GUIDE.md
@@ -93,14 +93,14 @@ Step 2: Installing DVOACAP...
 Step 3: Verifying installation...
 ============================================================
 Name: dvoacap
-Version: 1.0.1
+Version: 1.0.2
 Summary: Python port of DVOACAP HF propagation prediction engine
 ✓ DVOACAP package verified
 
 ============================================================
 Step 4: Testing import...
 ============================================================
-✓ DVOACAP imported successfully (version 1.0.1)
+✓ DVOACAP imported successfully (version 1.0.2)
 
 ============================================================
 ✓ INSTALLATION COMPLETE!
@@ -126,7 +126,7 @@ and run a basic HF propagation prediction.
 ============================================================
 [1/4] Testing package import...
 ============================================================
-✓ Successfully imported dvoacap (version 1.0.1)
+✓ Successfully imported dvoacap (version 1.0.2)
 
 ============================================================
 [2/4] Testing core components...

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 ![Python Version](https://img.shields.io/badge/python-3.11%2B-blue)
-![Version](https://img.shields.io/badge/version-1.0.1-blue)
+![Version](https://img.shields.io/badge/version-1.0.2-blue)
 ![Status](https://img.shields.io/badge/status-production%20ready-brightgreen)
 ![Validation](https://img.shields.io/badge/validation-86.6%25-brightgreen)
 ![Performance](https://img.shields.io/badge/performance-2.3x%20faster-orange)
@@ -15,7 +15,7 @@
 DVOACAP-Python is a modern Python port of the [DVOACAP](https://github.com/VE3NEA/DVOACAP) HF propagation prediction engine, originally written in Delphi/Pascal by Alex Shovkoplyas (VE3NEA). This project aims to provide an accessible, well-documented, and maintainable Python implementation of the VOACAP ionospheric propagation model.
 
 **Original DVOACAP by:** Alex Shovkoplyas, VE3NEA
-**Python Port:** Production Ready (v1.0.1, November 2025) - 2.3x faster than v1.0.0
+**Python Port:** Production Ready (v1.0.2, May 2026) - 2.3x faster than v1.0.0
 
 ## ⚡ Quick Start
 
@@ -205,7 +205,7 @@ See [src/dvoacap/dashboard/ISSUE_MULTI_USER_WEB_APP.md](src/dvoacap/dashboard/IS
 
 ## 📊 Project Status
 
-**Status: v1.0.1 Production Release** - 86.6% validation accuracy across 11 diverse test paths, 2.3x performance improvement
+**Status: v1.0.2 Production Release** - 86.6% validation accuracy across 11 diverse test paths, 2.3x performance improvement
 
 ### ✅ Completed Modules
 
@@ -267,7 +267,7 @@ See [src/dvoacap/dashboard/ISSUE_MULTI_USER_WEB_APP.md](src/dvoacap/dashboard/IS
 
 ### 📅 Planned
 
-- **PyPI public release** - Package ready (v1.0.1), pending publication decision
+- **PyPI public release** - Package ready (v1.0.2), pending publication decision
 - **Comprehensive type hints** - Add type annotations throughout codebase
 - **Sphinx API documentation** - Complete API reference with examples
 - **Community engagement** - Forum presence, user support, integration examples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dvoacap"
-version = "1.0.1"
+version = "1.0.2"
 description = "Python port of DVOACAP HF propagation prediction engine with 86.6% validation accuracy and 2.3x performance boost"
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.11"

--- a/src/dvoacap/__init__.py
+++ b/src/dvoacap/__init__.py
@@ -10,7 +10,7 @@ Python Port: 2025
 
 # Modern Python 3.11+ uses built-in types for annotations
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 __author__ = "Joel Morin and Contributors"
 __license__ = "MIT"
 


### PR DESCRIPTION
## Summary

Bump version from `1.0.1` → `1.0.2` in:
- `pyproject.toml`
- `src/dvoacap/__init__.py` (`__version__`)
- `README.md` badge + header
- `INSTALL_GUIDE.md` expected-output samples

Add a `## [1.0.2] - 2026-05-01` section to `CHANGELOG.md` summarising the user-facing fixes since v1.0.1:

- **#137** — Long-path signal/SNR fix. Engine no longer mixes the unimplemented `_evaluate_long_model` stub into predictions for paths > 7000 km, eliminating constant `-0.7 dBW` signal levels and absurd ±150 dB SNRs that the dashboard was rendering.
- **#137** — TX power now propagates to user-added antennas (was being shadowed by `select_antenna()`, leaving 100 W radios treated as 10 W).
- **#134 / #135** — Dashboard buttons (Refresh, Settings, Tabs) now responsive again. Duplicate `const now` declaration that produced a `SyntaxError` and prevented the entire `<script>` from parsing has been renamed.
- **#136** — Gray-line terminator drawn as a smooth analytic band instead of a stack of 10°-tall rectangles.
- **#133** — Dashboard ships as an installable subpackage with `dvoacap-dashboard` CLI entry point (`pip install dvoacap[dashboard]` works).

Historical references to v1.0.1 in `CLUB_PRESENTATION.md`, `NEXT_STEPS.md`, `PRESENTATION_GUIDE.md`, `KNOWN_ISSUES_CORRECTED.md`, `RELEASE_NOTES_v1.0.1.md`, and `GITHUB_RELEASE_v1.0.1.md` are deliberately left untouched — they describe past state.

## Post-merge steps (manual)

After this PR merges, on `main`:

```sh
git tag -a 1.0.2 -m "v1.0.2: dashboard fixes + long-path SNR fix"
git push origin 1.0.2
```

Then in GitHub UI: Releases → Draft new release → pick the `1.0.2` tag → paste the new CHANGELOG section as the body. If your PyPI release workflow is wired to tag pushes (per `PYPI_RELEASE_GUIDE.md`), it'll auto-publish.

## Test plan

- [x] `python -c "import dvoacap; print(dvoacap.__version__)"` reports `1.0.2`
- [x] All 322 existing tests pass
- [x] `git grep '1\.0\.1'` shows only intentionally-historical references (CHANGELOG `## [1.0.1]` heading, README's "Performance (v1.0.1)" attribution, the v1.0.1 release-note files)
- [ ] After merge + tag + GitHub release: `pip install --force-reinstall "dvoacap[dashboard] @ git+https://github.com/skyelaird/dvoacap-python.git@1.0.2"` installs cleanly and reports v1.0.2

https://claude.ai/code/session_01BLfWHK9hf8k4aBBaQjfQa8

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLfWHK9hf8k4aBBaQjfQa8)_